### PR TITLE
remove stall activation link after update

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-cloud-agent (1.2.7) stable; urgency=medium
+
+  * Remove stall activation link after update from <= 1.2.6; no functional
+    changes
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Wed, 13 Dec 2023 21:52:25 +0600
+
 wb-cloud-agent (1.2.6) stable; urgency=medium
 
   * Add daemon mode 

--- a/debian/wb-cloud-agent.postinst
+++ b/debian/wb-cloud-agent.postinst
@@ -33,6 +33,14 @@ if [ ! -f "$TARGET_CERT" ] || ! cert_is_valid "$TARGET_CERT"; then
     fi
 fi
 
+# remove stall activation link file if updated from <=1.2.6
+if [ "$1" = "configure" ] && dpkg --compare-versions "$2" lt "1.2.7~~"; then
+    if [ -e "/var/lib/wb-cloud-agent/telegraf.conf" ] && [ -e "/var/lib/wb-cloud-agent/activation_link.conf" ]; then
+        echo "Controller seems to be in the cloud already, removing stall activation link"
+        echo "unknown" > "/var/lib/wb-cloud-agent/activation_link.conf"
+    fi
+fi
+
 # fix agent config (ATECC path according to device version)
 . /usr/lib/wb-utils/wb_env.sh
 wb_source of

--- a/wb-cloud-agent
+++ b/wb-cloud-agent
@@ -2,6 +2,7 @@
 import argparse
 import json
 import logging
+import os
 import subprocess
 import sys
 import time
@@ -140,6 +141,9 @@ def write_activation_link(link, mqtt):
 
 
 def read_activation_link():
+    if not os.path.exists(settings.ACTIVATION_LINK_CONFIG):
+        return "unknown"
+
     with open(settings.ACTIVATION_LINK_CONFIG, "r") as file:
         return file.readline()
 


### PR DESCRIPTION
Саша Дегтярёв обнаружил, что после обновления на 1.2.6 в homeui начинает выводиться activation link, хотя контроллер уже подключен к облаку. Это всё происходит немножко из-за текущей архитектуры, так что по-хорошему нужны фундаментальные правки (например, если сделать FR контроллеру, не подключенному к облаку, но ранее загружавшему wb-cloud-agent, ссылку на подключение придётся подождать).

Этим PR проблема просто затыкается: проверяем, что на контроллере уже есть конфиг telegraf (== есть подключение к облаку), и если он есть, то удаляем файл ссылки.