### PR TITLE
remove unused dependency on wb-configs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-cloud-agent (1.2.8) stable; urgency=medium
+
+  * remove unused dependency on wb-configs, no functional changes
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Thu, 14 Dec 2023 18:31:17 +0600
+
 wb-cloud-agent (1.2.7) stable; urgency=medium
 
   * Remove stall activation link after update from <= 1.2.6; no functional

--- a/debian/control
+++ b/debian/control
@@ -15,8 +15,7 @@ Depends: ${misc:Depends},
          telegraf-wb-cloud-agent | telegraf,
          frpc,
          curl,
-         python3-wb-common (>= 2.1.1),
-         wb-configs (>= 3.20.0~~)
+         python3-wb-common (>= 2.1.1)
 Recommends: wb-mqtt-homeui (>= 2.77.0~~)
 Description: Wiren Board Cloud agent
  This package provides Wiren Board Cloud agent service.


### PR DESCRIPTION
Ломает использование агента в wb-2310, при этом реальной зависимости от wb-configs нет после перехода на curl вместо nginx