### PR TITLE
Get current activation status on agent start up

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-cloud-agent (1.3.0) UNRELEASED; urgency=medium
+
+  * Receive activation status and link on agent start up
+  * Allow unknown event codes without errors to improve future compatibility
+
+ -- kazqvaizer <kazqvaizer@fands.dev>  Mon, 05 Feb 2024 16:49:09 +1000
+
 wb-cloud-agent (1.2.8) stable; urgency=medium
 
   * remove unused dependency on wb-configs, no functional changes

--- a/wb-cloud-agent
+++ b/wb-cloud-agent
@@ -248,7 +248,7 @@ def make_start_up_request(mqtt):
     status_data, http_status = do_curl(method="get", endpoint="agent-start-up/")
     if http_status != HTTP_200_OK:
         raise ValueError("Not a 200 status while making start up request: " + str(http_status))
-    
+
     if "activated" not in status_data or "activationLink" not in status_data:
         raise ValueError("Invalid response data while making start up request: " + str(status_data))
 


### PR DESCRIPTION
  * Receive activation status and link on agent start up
  * Allow unknown event codes without errors to improve future compatibility
