### PR TITLE
fix unicode crash in non-unicode terminal

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-cloud-agent (1.3.1) stable; urgency=medium
+
+  * Console mode fix
+
+ -- Aleksandr Kazadaev <aleksandr.kazadaev@wirenboard.com>  Fri, 9 Feb 2024 14:31:17 +0600
+
 wb-cloud-agent (1.3.0) UNRELEASED; urgency=medium
 
   * Receive activation status and link on agent start up

--- a/wb-cloud-agent
+++ b/wb-cloud-agent
@@ -278,7 +278,7 @@ def main():
     if not options.daemon:
         link = read_activation_link()
         if link != "unknown":
-            print(f"👉 {link}")
+            print(f">> {link}")
         else:
             print("No active link. Controller may be already connected")
         return


### PR DESCRIPTION
Кажется, использовать эмодзи в терминале не получилось.