### PR TITLE
Feature/73262 proper shutdown status

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-cloud-agent (1.4.2) stable; urgency=medium
+
+  * Fixes around cloud connection status, no functional changes
+
+ -- Aleksandr Kazadaev <aleksandr.kazadaev@wirenboard.com>  Fri, 12 Apr 2024 16:30:17 +0500
+
 wb-cloud-agent (1.4.1) stable; urgency=medium
 
   * Bugfix with cloud url in config

--- a/wb-cloud-agent
+++ b/wb-cloud-agent
@@ -225,7 +225,7 @@ def publish_vdev(settings: AppSettings, mqtt):
         retain=True,
         qos=2,
     )
-    mqtt.publish(settings.MQTT_PREFIX + "/controls/status", "disconnected", retain=True, qos=2)
+    mqtt.publish(settings.MQTT_PREFIX + "/controls/status", "connecting", retain=True, qos=2)
     mqtt.publish(
         settings.MQTT_PREFIX + "/controls/activation_link", read_activation_link(settings), retain=True, qos=2
     )

--- a/wb-cloud-agent
+++ b/wb-cloud-agent
@@ -379,7 +379,7 @@ def run_daemon(mqtt, settings):
                 make_event_request(settings, mqtt)
             except Exception as ex:
                 logging.exception("Error making request to cloud!")
-                publish_ctrl(settings, mqtt, "status", "error:" + str(ex))
+                publish_ctrl(settings, mqtt, "status", "error: " + str(ex))
             else:
                 publish_ctrl(settings, mqtt, "status", "ok")
             request_time = time.perf_counter() - start
@@ -398,17 +398,21 @@ def main():
     mqtt = MQTTClient(f"wb-cloud-agent@{cloud_provider}", userdata={"settings": settings})
     mqtt.on_connect = on_connect
     mqtt.on_message = on_message
-    mqtt.will_set(settings.MQTT_PREFIX + "/controls/status", "stopped", retain=True, qos=2)
-    mqtt.start()
 
     if hasattr(options, "func"):
+        mqtt.start()
         return options.func(options, settings, mqtt)
 
-    update_providers_list(settings, mqtt)
-    make_start_up_request(settings, mqtt)
-
     if not options.daemon:
+        mqtt.start()
+        make_start_up_request(settings, mqtt)
         return show_activation_link(settings)
+
+    mqtt.will_set(settings.MQTT_PREFIX + "/controls/status", "stopped", retain=True, qos=2)
+    mqtt.start()
+    publish_ctrl(settings, mqtt, "status", "starting")
+    make_start_up_request(settings, mqtt)
+    update_providers_list(settings, mqtt)
 
     run_daemon(mqtt, settings)
 

--- a/wb-cloud-agent
+++ b/wb-cloud-agent
@@ -398,6 +398,7 @@ def main():
     mqtt = MQTTClient(f"wb-cloud-agent@{cloud_provider}", userdata={"settings": settings})
     mqtt.on_connect = on_connect
     mqtt.on_message = on_message
+    mqtt.will_set(settings.MQTT_PREFIX + "/controls/status", "stopped", retain=True, qos=2)
     mqtt.start()
 
     if hasattr(options, "func"):


### PR DESCRIPTION
Тестинг-сет: deb http://deb.wirenboard.com/all experimental.cloud-agent-shutdown-status main

Добавлены статусы starting, connecting и stopped. 
stopped выставляется самим mqtt-брокером как last will message при любом отключении wb-cloud-agent, соответственно, будет автоматом выставляться даже если сервис убить по kill -9 (кстати, это можно проверить).

В homeui есть ответные правки, оно тоже идет в тестинг-сете.