### PR TITLE
SOFT-3653: Send diagnostics to the cloud backend by request

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-cloud-agent (1.4.6) stable; urgency=medium
+
+  * Send diagnostics to the cloud backend by request
+
+ -- Dmitry Fedichkin <dmitrii.fedichkin@wirenboard.com>  Tue, 04 Jun 2024 17:10:17 +0200
+
 wb-cloud-agent (1.4.5) stable; urgency=medium
 
   * Fix service unit

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-wb-cloud-agent (1.4.6) stable; urgency=medium
+wb-cloud-agent (1.5.0) stable; urgency=medium
 
   * Send diagnostics to the cloud backend by request
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-cloud-agent (1.4.4) stable; urgency=medium
+
+  * Send diagnostics to the cloud backend by request
+
+ -- Dmitry Fedichkin <dmitrii.fedichkin@wirenboard.com>  Thu, 30 May 2024 17:10:17 +0200
+
 wb-cloud-agent (1.4.3) stable; urgency=medium
 
   * Fixes around cloud connection status

--- a/wb/cloud_agent/main.py
+++ b/wb/cloud_agent/main.py
@@ -223,14 +223,16 @@ def upload_diagnostic(settings: AppSettings):
     if http_status != HTTP_200_OK:
         logging.error("Not a 200 status while making upload_diagnostic request: " + str(http_status))
 
-    subprocess.run(f"rm {last_diagnostic}", shell=True)
+    os.remove(last_diagnostic)
 
 
 def fetch_diagnostics(settings: AppSettings, payload, mqtt):
+    # remove old diagnostics
     try:
-        subprocess.run(f"rm {DIAGNOSTIC_DIR}/diag_*.zip", shell=True)
-    except OSError:
-        logging.warning(f"Erase diagnostic files failed")
+        for fname in glob.glob(f"{DIAGNOSTIC_DIR}/diag_*.zip"):
+            os.remove(fname)
+    except OSError as e:
+        logging.warning(f"Erase diagnostic files failed: {e.strerror}")
 
     process = subprocess.Popen(
         "wb-diag-collect diag",

--- a/wb/cloud_agent/main.py
+++ b/wb/cloud_agent/main.py
@@ -208,12 +208,17 @@ def callback(settings: AppSettings):
     files = sorted(glob.glob(os.path.join(DIAGNOSTIC_DIR, "diag_*.zip")), key=os.path.getmtime)
     if not files:
         logging.error("No diagnostics collected")
+        _, http_status = do_curl(
+            settings=settings, method="put", endpoint="diagnostic-status/", params={"status": "error"}
+        )
+        if http_status != HTTP_200_OK:
+            logging.error("Not a 200 status while updating diagnostic status: " + str(http_status))
         return
 
     last_diagnostic = files[-1]
     logging.info(f"Diagnostics collected: {last_diagnostic}")
     data, http_status = do_curl(
-        settings=settings, method="multipart-post", endpoint="upload_diagnostic/", params=last_diagnostic
+        settings=settings, method="multipart-post", endpoint="upload-diagnostic/", params=last_diagnostic
     )
     if http_status != HTTP_200_OK:
         logging.error("Not a 200 status while making upload_diagnostic request: " + str(http_status))


### PR DESCRIPTION
По событию `fetch_diagnostics ` собираем диагностику и по готовности отправляем в cloud-backend. Уведомляем backend, если при сборке диагностики произошла ошибка.