### PR TITLE
Substitute mqtt broker url in telegraf config

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-cloud-agent (1.5.1) stable; urgency=medium
+
+  * Substitute mqtt broker url in telegraf config
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Thu, 20 Jun 2024 16:00:00 +0400
+
 wb-cloud-agent (1.5.0) stable; urgency=medium
 
   * Send diagnostics to the cloud backend by request
@@ -80,7 +86,7 @@ wb-cloud-agent (1.2.7) stable; urgency=medium
 
 wb-cloud-agent (1.2.6) stable; urgency=medium
 
-  * Add daemon mode 
+  * Add daemon mode
   * Fix initial value in activation link topic
 
  -- Ekaterina Volkova <ekaterina.volkova@wirenboard.ru>  Wed, 13 Dec 2023 12:54:53 +0300

--- a/wb/cloud_agent/main.py
+++ b/wb/cloud_agent/main.py
@@ -9,6 +9,7 @@ import threading
 import time
 from contextlib import ExitStack
 from json import JSONDecodeError
+from string import Template
 
 from wb_common.mqtt_client import DEFAULT_BROKER_URL, MQTTClient
 
@@ -199,7 +200,7 @@ def update_tunnel_config(settings: AppSettings, payload, mqtt):
 
 def update_metrics_config(settings: AppSettings, payload, mqtt):
     with open(settings.TELEGRAF_CONFIG, "w") as file:
-        file.write(payload["config"])
+        file.write(Template(payload["config"]).safe_substitute(BROKER_URL=settings.BROKER_URL))
     start_service(settings.TELEGRAF_SERVICE, restart=True)
     write_activation_link(settings, "unknown", mqtt)
 
@@ -461,9 +462,11 @@ def main():
 
     setup_log(settings)
 
-    options.broker = options.broker or settings.BROKER_URL
+    settings.BROKER_URL = options.broker or settings.BROKER_URL
 
-    mqtt = MQTTClient(f"wb-cloud-agent@{cloud_provider}", options.broker, userdata={"settings": settings})
+    mqtt = MQTTClient(
+        f"wb-cloud-agent@{cloud_provider}", settings.BROKER_URL, userdata={"settings": settings}
+    )
     mqtt.on_connect = on_connect
     mqtt.on_message = on_message
 

--- a/wb/cloud_agent/main.py
+++ b/wb/cloud_agent/main.py
@@ -205,7 +205,7 @@ def update_tunnel_config(settings: AppSettings, payload, mqtt):
 def update_metrics_config(settings: AppSettings, payload, mqtt):
     write_to_file(
         fpath=settings.TELEGRAF_CONFIG,
-        contents=Template(payload["config"]).safe_substitute(BROKER_URL=settings.BROKER_URL)
+        contents=Template(payload["config"]).safe_substitute(BROKER_URL=settings.BROKER_URL),
     )
     start_service(settings.TELEGRAF_SERVICE, restart=True)
     write_activation_link(settings, "unknown", mqtt)


### PR DESCRIPTION
Бэк сможет возвращать конфиг телеграфа в виде (для агентов >=1.5.2):
```
...
[[inputs.mqtt_consumer]]
  servers = ["$BROKER_URL"]
...
```