### PR TITLE
Move device certs check to ExecStartPre

### DIFF
--- a/check-certs.sh
+++ b/check-certs.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -e
+
+print_bundle_part() {
+    awk -v "req_part=$1" 'BEGIN { c = 0; } /BEGIN CERT/{c++} c == req_part { print }'
+}
+
+cert_is_valid() {
+    (openssl x509 -in "$1" -noout -subject || true) | grep -q "Production"
+}
+
+ORIGINAL_CERT=/etc/ssl/certs/device_bundle.crt.pem
+TARGET_CERT=/var/lib/wb-cloud-agent/device_bundle.crt.pem
+
+if [ ! -f "$ORIGINAL_CERT" ]; then
+    echo "Can't find device certificate!"
+    exit 1
+fi
+
+mkdir -p /var/lib/wb-cloud-agent
+
+# create correct certificate for agent to use
+if [ ! -f "$TARGET_CERT" ] || ! cert_is_valid "$TARGET_CERT"; then
+    if cert_is_valid "$ORIGINAL_CERT"; then
+        echo "Device cert is OK, reusing it"
+        rm -f "$TARGET_CERT"
+        ln -s "$ORIGINAL_CERT" "$TARGET_CERT"
+    else
+        echo "Creating fixed bundle certificate"
+        print_bundle_part 2 < "$ORIGINAL_CERT" > "$TARGET_CERT"
+        print_bundle_part 1 < "$ORIGINAL_CERT" >> "$TARGET_CERT"
+    fi
+fi
+
+# fix agent config (ATECC path according to device version)
+. /usr/lib/wb-utils/wb_env.sh
+wb_source of
+
+if of_machine_match "wirenboard,wirenboard-720"; then
+    sed -i 's/ATECCx08:00:../ATECCx08:00:02/g' /mnt/data/etc/wb-cloud-agent.conf
+elif of_machine_match "contactless,imx6ul-wirenboard60"; then
+    sed -i 's/ATECCx08:00:../ATECCx08:00:04/g' /mnt/data/etc/wb-cloud-agent.conf
+fi

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-cloud-agent (1.3.3-wb105) stable; urgency=medium
+
+  * Move device certs check to ExecStartPre (instead of postinst)
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 29 Jul 2024 20:00:00 +0400
+
 wb-cloud-agent (1.3.3-wb104) stable; urgency=medium
 
   * Handle TimeoutExpired exception during events polling

--- a/debian/wb-cloud-agent.install
+++ b/debian/wb-cloud-agent.install
@@ -1,2 +1,3 @@
 wb-cloud-agent /usr/bin/
 wb-cloud-agent.conf /mnt/data/etc/
+check-certs.sh /usr/lib/wb-cloud-agent/

--- a/debian/wb-cloud-agent.postinst
+++ b/debian/wb-cloud-agent.postinst
@@ -2,53 +2,12 @@
 
 set -e
 
-print_bundle_part() {
-    awk -v "req_part=$1" 'BEGIN { c = 0; } /BEGIN CERT/{c++} c == req_part { print }'
-}
-
-cert_is_valid() {
-    (openssl x509 -in "$1" -noout -subject || true) | grep -q "Production"
-}
-
-ORIGINAL_CERT=/etc/ssl/certs/device_bundle.crt.pem
-TARGET_CERT=/var/lib/wb-cloud-agent/device_bundle.crt.pem
-
-if [ ! -f "$ORIGINAL_CERT" ]; then
-    echo "Can't find device certificate!"
-    exit 1
-fi
-
-mkdir -p /var/lib/wb-cloud-agent
-
-# create correct certificate for agent to use
-if [ ! -f "$TARGET_CERT" ] || ! cert_is_valid "$TARGET_CERT"; then
-    if cert_is_valid "$ORIGINAL_CERT"; then
-        echo "Device cert is OK, reusing it"
-        rm -f "$TARGET_CERT"
-        ln -s "$ORIGINAL_CERT" "$TARGET_CERT"
-    else
-        echo "Creating fixed bundle certificate"
-        print_bundle_part 2 < "$ORIGINAL_CERT" > "$TARGET_CERT"
-        print_bundle_part 1 < "$ORIGINAL_CERT" >> "$TARGET_CERT"
-    fi
-fi
-
 # remove stall activation link file if updated from <=1.2.6
 if [ "$1" = "configure" ] && dpkg --compare-versions "$2" lt "1.2.7~~"; then
     if [ -e "/var/lib/wb-cloud-agent/telegraf.conf" ] && [ -e "/var/lib/wb-cloud-agent/activation_link.conf" ]; then
         echo "Controller seems to be in the cloud already, removing stall activation link"
         echo "unknown" > "/var/lib/wb-cloud-agent/activation_link.conf"
     fi
-fi
-
-# fix agent config (ATECC path according to device version)
-. /usr/lib/wb-utils/wb_env.sh
-wb_source of
-
-if of_machine_match "wirenboard,wirenboard-720"; then
-    sed -i 's/ATECCx08:00:../ATECCx08:00:02/g' /mnt/data/etc/wb-cloud-agent.conf
-elif of_machine_match "contactless,imx6ul-wirenboard60"; then
-    sed -i 's/ATECCx08:00:../ATECCx08:00:04/g' /mnt/data/etc/wb-cloud-agent.conf
 fi
 
 #DEBHELPER#

--- a/debian/wb-cloud-agent.wb-cloud-agent.service
+++ b/debian/wb-cloud-agent.wb-cloud-agent.service
@@ -5,6 +5,7 @@ StartLimitBurst=100
 
 [Service]
 ExecStart=/usr/bin/wb-cloud-agent --daemon
+ExecStartPre=/usr/lib/wb-cloud-agent/check-certs.sh
 Restart=always
 RestartSec=10
 


### PR DESCRIPTION
Backport of https://github.com/wirenboard/wb-cloud-agent/pull/21/commits/916ee4e99867dc6fb2811a2fa10c4ba46c2b5912 and https://github.com/wirenboard/wb-cloud-agent/pull/21/commits/88b75dd6b97cdf66baff3afaf26da0aa70e27720 to be able to install wb-cloud-agent into FIT image.