### PR TITLE
Backup config via wb-configs

### DIFF
--- a/19wb-cloud-agent
+++ b/19wb-cloud-agent
@@ -1,0 +1,1 @@
+wb_move /etc/wb-cloud-agent.conf

--- a/check-certs.sh
+++ b/check-certs.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+AGENT_CONFIG="/etc/wb-cloud-agent.conf"
+
 print_bundle_part() {
     awk -v "req_part=$1" 'BEGIN { c = 0; } /BEGIN CERT/{c++} c == req_part { print }'
 }
@@ -38,7 +40,7 @@ fi
 wb_source of
 
 if of_machine_match "wirenboard,wirenboard-720"; then
-    sed -i 's/ATECCx08:00:../ATECCx08:00:02/g' /mnt/data/etc/wb-cloud-agent.conf
+    sed -i 's/ATECCx08:00:../ATECCx08:00:02/g' "$AGENT_CONFIG"
 elif of_machine_match "contactless,imx6ul-wirenboard60"; then
-    sed -i 's/ATECCx08:00:../ATECCx08:00:04/g' /mnt/data/etc/wb-cloud-agent.conf
+    sed -i 's/ATECCx08:00:../ATECCx08:00:04/g' "$AGENT_CONFIG"
 fi

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-cloud-agent (1.3.3-wb106) stable; urgency=medium
+
+  * Backup config via wb-configs
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 31 Jul 2024 18:00:00 +0400
+
 wb-cloud-agent (1.3.3-wb105) stable; urgency=medium
 
   * Move device certs check to ExecStartPre (instead of postinst)

--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,8 @@ Depends: ${misc:Depends},
          telegraf-wb-cloud-agent | telegraf,
          frpc,
          curl,
-         python3-wb-common (>= 2.1.1)
+         python3-wb-common (>= 2.1.1),
+         wb-utils
 Recommends: wb-mqtt-homeui (>= 2.77.0~~)
 Description: Wiren Board Cloud agent
  This package provides Wiren Board Cloud agent service.

--- a/debian/wb-cloud-agent.install
+++ b/debian/wb-cloud-agent.install
@@ -1,3 +1,4 @@
 wb-cloud-agent /usr/bin/
-wb-cloud-agent.conf /mnt/data/etc/
+wb-cloud-agent.conf /etc/
+19wb-cloud-agent /etc/wb-configs.d/
 check-certs.sh /usr/lib/wb-cloud-agent/

--- a/wb-cloud-agent
+++ b/wb-cloud-agent
@@ -17,8 +17,8 @@ from wb_common.mqtt_client import DEFAULT_BROKER_URL, MQTTClient
 
 HTTP_200_OK = 200
 HTTP_204_NO_CONTENT = 204
-DEFAULT_CONF_FILE = "/mnt/data/etc/wb-cloud-agent.conf"
-PACKAGE_VERSION = "1.3.3-wb103"
+DEFAULT_CONF_FILE = "/etc/wb-cloud-agent.conf"
+PACKAGE_VERSION = "1.3.3-wb106"
 DIAGNOSTIC_DIR = "/tmp"
 
 


### PR DESCRIPTION
Backport of https://github.com/wirenboard/wb-cloud-agent/commit/1a1110b7808f365068d2f6bfe1c6243209f2f348
Сейчас конфиг устанавливается в /mnt/data/etc, как следствие при установке в фит его нет и агент не стартует.