### PR TITLE
Отключение запуска wb-cloud-agent-frpc вместе с системой

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-cloud-agent (1.5.9) stable; urgency=medium
+
+  * Disable wb-cloud-agent-frpc service on boot to reduce logs after system reboot
+
+ -- Nikita Chernykh <nikita.chernykh@wirenboard.com>  Mon, 09 Sep 2024 10:00:00 +0400
+
 wb-cloud-agent (1.5.8) stable; urgency=medium
 
   * Refactor mqtt client, no functional changes

--- a/debian/wb-cloud-agent.wb-cloud-agent-frpc.service
+++ b/debian/wb-cloud-agent.wb-cloud-agent-frpc.service
@@ -5,8 +5,8 @@ StartLimitIntervalSec=3600
 StartLimitBurst=100
 
 [Service]
-ExecCondition=/usr/bin/test -f /run/frpc.conf
-ExecStart=/usr/bin/frpc --config /run/frpc.conf
+ExecCondition=/usr/bin/test -f /run/wb-cloud-agent/frpc.conf
+ExecStart=/usr/bin/frpc --config /run/wb-cloud-agent/frpc.conf
 Restart=always
 RestartSec=10
 

--- a/debian/wb-cloud-agent.wb-cloud-agent-frpc.service
+++ b/debian/wb-cloud-agent.wb-cloud-agent-frpc.service
@@ -5,8 +5,8 @@ StartLimitIntervalSec=3600
 StartLimitBurst=100
 
 [Service]
-ExecCondition=/usr/bin/test -f /var/lib/wb-cloud-agent/frpc.conf
-ExecStart=/usr/bin/frpc --config /var/lib/wb-cloud-agent/frpc.conf
+ExecCondition=/usr/bin/test -f /run/frpc.conf
+ExecStart=/usr/bin/frpc --config /run/frpc.conf
 Restart=always
 RestartSec=10
 

--- a/debian/wb-cloud-agent.wb-cloud-agent-frpc@.service
+++ b/debian/wb-cloud-agent.wb-cloud-agent-frpc@.service
@@ -5,8 +5,8 @@ StartLimitIntervalSec=3600
 StartLimitBurst=100
 
 [Service]
-ExecCondition=/usr/bin/test -f /var/lib/wb-cloud-agent/providers/%i/frpc.conf
-ExecStart=/usr/bin/frpc --config /var/lib/wb-cloud-agent/providers/%i/frpc.conf
+ExecCondition=/usr/bin/test -f /run/frpc-%i.conf
+ExecStart=/usr/bin/frpc --config /run/frpc-%i.conf
 Restart=always
 RestartSec=10
 

--- a/debian/wb-cloud-agent.wb-cloud-agent-frpc@.service
+++ b/debian/wb-cloud-agent.wb-cloud-agent-frpc@.service
@@ -5,8 +5,8 @@ StartLimitIntervalSec=3600
 StartLimitBurst=100
 
 [Service]
-ExecCondition=/usr/bin/test -f /run/frpc-%i.conf
-ExecStart=/usr/bin/frpc --config /run/frpc-%i.conf
+ExecCondition=/usr/bin/test -f /run/wb-cloud-agent-%i/frpc.conf
+ExecStart=/usr/bin/frpc --config /run/wb-cloud-agent-%i/frpc.conf
 Restart=always
 RestartSec=10
 

--- a/debian/wb-cloud-agent.wb-cloud-agent.service
+++ b/debian/wb-cloud-agent.wb-cloud-agent.service
@@ -6,6 +6,7 @@ StartLimitIntervalSec=3600
 StartLimitBurst=100
 
 [Service]
+RuntimeDirectory=wb-cloud-agent
 ExecStart=/usr/bin/wb-cloud-agent --daemon --provider default
 ExecStartPre=/usr/lib/wb-cloud-agent/check-certs.sh
 ExecStartPre=/usr/lib/wb-cloud-agent/activate-providers.sh

--- a/debian/wb-cloud-agent.wb-cloud-agent@.service
+++ b/debian/wb-cloud-agent.wb-cloud-agent@.service
@@ -7,6 +7,7 @@ StartLimitBurst=100
 ConditionPathExistsGlob=/etc/wb-cloud-agent/providers/%i/*.conf
 
 [Service]
+RuntimeDirectory=wb-cloud-agent-%i
 ExecStart=/usr/bin/wb-cloud-agent --daemon --provider %i
 ExecStartPre=/usr/lib/wb-cloud-agent/check-certs.sh
 ExecStartPre=/usr/lib/wb-cloud-agent/activate-providers.sh

--- a/wb/cloud_agent/main.py
+++ b/wb/cloud_agent/main.py
@@ -26,9 +26,9 @@ DIAGNOSTIC_DIR = "/tmp"
 def start_service(service: str, restart=False, enable=True):
     if enable:
         subprocess.run(["systemctl", "enable", service], check=True)
-    else 
+    else: 
         subprocess.run(["systemctl", "disable", service], check=True)
-    
+
     if restart:
         print(f"Restarting service {service}")
         subprocess.run(["systemctl", "restart", service], check=True)

--- a/wb/cloud_agent/main.py
+++ b/wb/cloud_agent/main.py
@@ -23,8 +23,12 @@ PROVIDERS_CONF_DIR = "/etc/wb-cloud-agent/providers"
 DIAGNOSTIC_DIR = "/tmp"
 
 
-def start_service(service: str, restart=False):
-    subprocess.run(["systemctl", "enable", service], check=True)
+def start_service(service: str, restart=False, enable=True):
+    if enable:
+        subprocess.run(["systemctl", "enable", service], check=True)
+    else 
+        subprocess.run(["systemctl", "disable", service], check=True)
+    
     if restart:
         print(f"Restarting service {service}")
         subprocess.run(["systemctl", "restart", service], check=True)
@@ -127,7 +131,7 @@ def update_activation_link(settings: AppSettings, payload, mqtt):
 
 def update_tunnel_config(settings: AppSettings, payload, mqtt):
     write_to_file(fpath=settings.FRP_CONFIG, contents=payload["config"])
-    start_service(settings.FRP_SERVICE, restart=True)
+    start_service(settings.FRP_SERVICE, restart=True, enable=False)
     write_activation_link(settings, "unknown", mqtt)
 
 

--- a/wb/cloud_agent/main.py
+++ b/wb/cloud_agent/main.py
@@ -26,7 +26,7 @@ DIAGNOSTIC_DIR = "/tmp"
 def start_service(service: str, restart=False, enable=True):
     if enable:
         subprocess.run(["systemctl", "enable", service], check=True)
-    else: 
+    else:
         subprocess.run(["systemctl", "disable", service], check=True)
 
     if restart:

--- a/wb/cloud_agent/settings.py
+++ b/wb/cloud_agent/settings.py
@@ -37,14 +37,14 @@ class AppSettings:  # pylint: disable=too-many-instance-attributes disable=too-f
             self.CONFIG_FILE: str = DEFAULT_CONF_FILE
             self.FRP_SERVICE: str = "wb-cloud-agent-frpc.service"
             self.TELEGRAF_SERVICE: str = "wb-cloud-agent-telegraf.service"
-            self.FRP_CONFIG: str = "/run/frpc.conf"
+            self.FRP_CONFIG: str = "/run/wb-cloud-agent/frpc.conf"
             self.TELEGRAF_CONFIG: str = "/var/lib/wb-cloud-agent/telegraf.conf"
             self.ACTIVATION_LINK_CONFIG: str = "/var/lib/wb-cloud-agent/activation_link.conf"
         else:
             self.CONFIG_FILE: str = f"{PROVIDERS_CONF_DIR}/{provider}/wb-cloud-agent.conf"
             self.FRP_SERVICE: str = f"wb-cloud-agent-frpc@{provider}.service"
             self.TELEGRAF_SERVICE: str = f"wb-cloud-agent-telegraf@{provider}.service"
-            self.FRP_CONFIG: str = f"/run/frpc-{provider}.conf"
+            self.FRP_CONFIG: str = f"/run/wb-cloud-agent-{provider}/frpc.conf"
             self.TELEGRAF_CONFIG: str = f"/var/lib/wb-cloud-agent/providers/{provider}/telegraf.conf"
             self.ACTIVATION_LINK_CONFIG: str = (
                 f"/var/lib/wb-cloud-agent/providers/{provider}/activation_link.conf"

--- a/wb/cloud_agent/settings.py
+++ b/wb/cloud_agent/settings.py
@@ -37,14 +37,14 @@ class AppSettings:  # pylint: disable=too-many-instance-attributes disable=too-f
             self.CONFIG_FILE: str = DEFAULT_CONF_FILE
             self.FRP_SERVICE: str = "wb-cloud-agent-frpc.service"
             self.TELEGRAF_SERVICE: str = "wb-cloud-agent-telegraf.service"
-            self.FRP_CONFIG: str = "/var/lib/wb-cloud-agent/frpc.conf"
+            self.FRP_CONFIG: str = "/run/frpc.conf"
             self.TELEGRAF_CONFIG: str = "/var/lib/wb-cloud-agent/telegraf.conf"
             self.ACTIVATION_LINK_CONFIG: str = "/var/lib/wb-cloud-agent/activation_link.conf"
         else:
             self.CONFIG_FILE: str = f"{PROVIDERS_CONF_DIR}/{provider}/wb-cloud-agent.conf"
             self.FRP_SERVICE: str = f"wb-cloud-agent-frpc@{provider}.service"
             self.TELEGRAF_SERVICE: str = f"wb-cloud-agent-telegraf@{provider}.service"
-            self.FRP_CONFIG: str = f"/var/lib/wb-cloud-agent/providers/{provider}/frpc.conf"
+            self.FRP_CONFIG: str = f"/run/frpc-{provider}.conf"
             self.TELEGRAF_CONFIG: str = f"/var/lib/wb-cloud-agent/providers/{provider}/telegraf.conf"
             self.ACTIVATION_LINK_CONFIG: str = (
                 f"/var/lib/wb-cloud-agent/providers/{provider}/activation_link.conf"


### PR DESCRIPTION
Чтобы frpc не засорял логи (из-за того что после перезагрузки токен недействительный) отключаем его старт вместе с системой - его перезапустит wb-cloud-agent после получения свежего конфига. 

Также переместил конфиг frpc в /run чтобы он удалялся при выключении