### PR TITLE
Restart alternative cloud services when main agent is restarting

### DIFF
--- a/activate-providers.sh
+++ b/activate-providers.sh
@@ -4,9 +4,6 @@ set -e
 
 if [ -d /etc/wb-cloud-agent/providers ]; then
     for provider in $(ls /etc/wb-cloud-agent/providers/); do
-        if ! systemctl -q is-enabled wb-cloud-agent@$provider; then
-            systemctl enable wb-cloud-agent@$provider
-            systemctl restart wb-cloud-agent@$provider
-        fi
+        systemctl restart wb-cloud-agent@$provider
     done
 fi

--- a/check-certs.sh
+++ b/check-certs.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-AGENT_CONFIG="/etc/wb-cloud-agent.conf"
+AGENT_CONFIG="${1:-/etc/wb-cloud-agent.conf}"
 
 print_bundle_part() {
     awk -v "req_part=$1" '/BEGIN CERT/{c++} c == req_part { print }'

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-cloud-agent (1.5.10) stable; urgency=medium
+
+  * Restart alternative cloud services when main agent is restarting
+
+ --  Nikita Chernykh <nikita.chernykh@wirenboard.com>  Mon, 07 Oct 2024 10:00:00 +0300
+ 
 wb-cloud-agent (1.5.9) stable; urgency=medium
 
   * Add mqtt device republish on mosquitto restart

--- a/debian/wb-cloud-agent.wb-cloud-agent@.service
+++ b/debian/wb-cloud-agent.wb-cloud-agent@.service
@@ -8,8 +8,6 @@ ConditionPathExistsGlob=/etc/wb-cloud-agent/providers/%i/*.conf
 
 [Service]
 ExecStart=/usr/bin/wb-cloud-agent --daemon --provider %i
-ExecStartPre=/usr/lib/wb-cloud-agent/check-certs.sh
-ExecStartPre=/usr/lib/wb-cloud-agent/activate-providers.sh
 Restart=always
 RestartSec=10
 RestartPreventExitStatus=6

--- a/debian/wb-cloud-agent.wb-cloud-agent@.service
+++ b/debian/wb-cloud-agent.wb-cloud-agent@.service
@@ -7,6 +7,7 @@ StartLimitBurst=100
 ConditionPathExistsGlob=/etc/wb-cloud-agent/providers/%i/*.conf
 
 [Service]
+ExecStartPre=/usr/lib/wb-cloud-agent/check-certs.sh /etc/wb-cloud-agent/providers/%i/wb-cloud-agent.conf
 ExecStart=/usr/bin/wb-cloud-agent --daemon --provider %i
 Restart=always
 RestartSec=10


### PR DESCRIPTION
При перезапуске основного сервиса агента - перезапускам также сервисы с другими провайдерами и проверяем в них конфигурацию