### PR TITLE
Fix frpc service description

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,5 @@
 buildDebSbuild defaultTargets: "bullseye-host",
+               defaultRunLintian: true,
                defaultRunPythonChecks: true,
                defaultAngryPylint: true,
                defaultRunCoverage: true,

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-cloud-agent (1.5.13) stable; urgency=medium
+
+  * Fix frpc service description
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Thu, 27 Feb 2025 19:10:00 +0400
+
 wb-cloud-agent (1.5.12) stable; urgency=medium
 
   * Wait until the network is "up"
@@ -177,7 +183,7 @@ wb-cloud-agent (1.2.3) stable; urgency=low
 
   * Retry policy for curl to reduce number of cert errors
 
- -- kazqvaizer <kazqvaizer@kazqvaizer@gmail.com>  Wed, 29 Nov 2023 11:50:22 +1000
+ -- kazqvaizer <kazqvaizer@gmail.com>  Wed, 29 Nov 2023 11:50:22 +1000
 
 wb-cloud-agent (1.2.2) stable; urgency=low
 
@@ -185,7 +191,7 @@ wb-cloud-agent (1.2.2) stable; urgency=low
   * Proper logging levels
   * Settings now can be updated from config file
 
- -- kazqvaizer <kazqvaizer@kazqvaizer@gmail.com>  Fri, 24 Nov 2023 23:36:19 +1000
+ -- kazqvaizer <kazqvaizer@gmail.com>  Fri, 24 Nov 2023 23:36:19 +1000
 
 wb-cloud-agent (1.0.0) stable; urgency=low
 

--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: wb-cloud-agent
 Section: misc
 Priority: optional
-Maintainer: Nikita Maslov <nikita.maslov@wirenboard.ru>
+Maintainer: Wiren Board team <info@wirenboard.com>
 XS-Python-Version: >= 3.9
 Build-Depends: dh-python,
                debhelper-compat (= 13),
@@ -18,7 +18,7 @@ Rules-Requires-Root: no
 Package: wb-cloud-agent
 Architecture: all
 Depends: ${misc:Depends},
-         python3-all,
+         ${python3:Depends},
          python3-requests,
          telegraf-wb-cloud-agent | telegraf,
          frpc,

--- a/debian/wb-cloud-agent.wb-cloud-agent-frpc.service
+++ b/debian/wb-cloud-agent.wb-cloud-agent-frpc.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=telegraf metric sender for Wiren Board Cloud (default)
+Description=fast reverse proxy client for Wiren Board Cloud (default)
 After=wb-cloud-agent.service
 StartLimitIntervalSec=3600
 StartLimitBurst=100

--- a/debian/wb-cloud-agent.wb-cloud-agent-frpc@.service
+++ b/debian/wb-cloud-agent.wb-cloud-agent-frpc@.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=telegraf metric sender for Wiren Board Cloud (%i)
+Description=fast reverse proxy client for Wiren Board Cloud (%i)
 After=wb-cloud-agent.service
 StartLimitIntervalSec=3600
 StartLimitBurst=100


### PR DESCRIPTION
Fix wrong description:
```sh
# systemctl status wb-cloud-agent-frpc
● wb-cloud-agent-frpc.service - telegraf metric sender for Wiren Board Cloud (default)
     Loaded: loaded (/lib/systemd/system/wb-cloud-agent-frpc.service; enabled; preset: enabled)
```