### PR TITLE
add more explicit error message on invalid certs (possibly because of…

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-cloud-agent (1.5.14) stable; urgency=medium
+
+  * Add more explicit error message on invalid certs (possibly because of wrong CPU board)
+
+ -- Vladimir Romanov <v.romanov@wirenboard.com>  Thu, 10 Apr 2025 13:58:22 +0300
+
 wb-cloud-agent (1.5.13) stable; urgency=medium
 
   * Fix frpc service description

--- a/wb/cloud_agent/main.py
+++ b/wb/cloud_agent/main.py
@@ -83,7 +83,16 @@ def do_curl(settings: AppSettings, method="get", endpoint="", params=None):
         url,
     ]
 
-    result = subprocess.run(command, timeout=360, check=True, capture_output=True)
+    try:
+        result = subprocess.run(command, timeout=360, check=True, capture_output=True)
+    except subprocess.CalledProcessError as e:
+        if e.returncode == 58:
+            errmsg = (
+                f"Cert {settings.CLIENT_CERT_FILE} and key {settings.CLIENT_CERT_ENGINE_KEY} "
+                "seem to be inconsistent (possibly because of CPU board missmatch)!"
+            )
+            raise RuntimeError(errmsg) from e
+        raise e
 
     decoded_result = result.stdout.decode("utf-8")
     split_result = decoded_result.split(data_delimiter)


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
в cloud-чатик пришел @taraant с симптомами "нет ссылки для добавления в cloud".

Стали разбираться - выяснили, что он ковырял систему и добился того, что сертификаты в /etc/ssl/... не соответствуют физически напаянному крипто-чипу на wb => добавил более явное ругательство про это (т.к. помню пару старых кейсов от клиентов про такое)

___________________________________
**Что поменялось для пользователей:**
для пользователей - ничего; для нас - станет понятнее дебажить

___________________________________
**Как проверял/а:**
попортил сертификаты на живом wb - убедился, что ругается понятнее

