### PR TITLE
Fix postinst script

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-cloud-agent (1.6.2) stable; urgency=medium
+
+  * Fix postinst script
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 16 Jul 2025 15:10:00 +0400
+
 wb-cloud-agent (1.6.1) stable; urgency=medium
 
   * Add ability to remove controller from cloud when provider is deleted

--- a/debian/wb-cloud-agent.postinst
+++ b/debian/wb-cloud-agent.postinst
@@ -33,6 +33,8 @@ if [ "$1" = "configure" ]; then
     fi
 fi
 
-grep -qF "+update-from-cloud " /var/lib/wb-image-update/firmware-compatible || echo -n "+update-from-cloud " >> /var/lib/wb-image-update/firmware-compatible
+if [[ -e "/usr/sbin/policy-rc.d" ]] && [[ "$(cat /usr/sbin/policy-rc.d)" == "exit 101" ]]; then
+    grep -qF "+update-from-cloud " /var/lib/wb-image-update/firmware-compatible || echo -n "+update-from-cloud " >> /var/lib/wb-image-update/firmware-compatible
+fi
 
 #DEBHELPER#


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
```
Setting up wb-cloud-agent (1.6.1) ...
grep: /var/lib/wb-image-update/firmware-compatible: No such file or directory
/var/lib/dpkg/info/wb-cloud-agent.postinst: line 36: /var/lib/wb-image-update/firmware-compatible: No such file or directory
dpkg: error processing package wb-cloud-agent (--configure):
 installed wb-cloud-agent package post-installation script subprocess returned error exit status 1
Errors were encountered while processing:
 wb-cloud-agent
```
`/var/lib/wb-image-update/firmware-compatible` создается при сборке rootfs тут:
https://github.com/wirenboard/wb-utils/blob/13e14bf113ed41eb0982042660aa6a459aadd069/debian/postinst#L5-L8
Но на живой системе /var/lib/wb-image-update может уже совсем не быть. Тут аналогично надо дергать postinst только при сборке rootfs.
___________________________________
**Что поменялось для пользователей:**
ничего

___________________________________
**Как проверял/а:**
```sh
mv /var/lib/wb-image-update{,.bk}
apt install --reinstall wb-cloud-agent
```

