### PR TITLE
Fix postrm script

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-cloud-agent (1.6.6) stable; urgency=medium
+
+  * Fix postrm script
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Tue, 09 Sep 2025 15:00:00 +0400
+
 wb-cloud-agent (1.6.5) stable; urgency=medium
 
   * Fix bug with ConnectionError to mqtt when add provider

--- a/debian/wb-cloud-agent.postinst
+++ b/debian/wb-cloud-agent.postinst
@@ -43,7 +43,7 @@ if [ "$1" = "configure" ]; then
 
     echo "Add default wirenboard.cloud provider"
     wb-cloud-agent add-provider https://wirenboard.cloud || true
-    fi
+  fi
 fi
 
 if [[ -e "/usr/sbin/policy-rc.d" ]] && [[ "$(cat /usr/sbin/policy-rc.d)" == "exit 101" ]]; then

--- a/debian/wb-cloud-agent.postrm
+++ b/debian/wb-cloud-agent.postrm
@@ -7,12 +7,16 @@ if [ -L /etc/nginx/sites-enabled/wb-cloud-agent ]; then
 fi
 
 if [ "$1" = "remove" ]; then
-    echo "Removing wb-cloud-agent devices from MQTT"
-    mqtt-delete-retained "/wb-cloud-agent/#" >/dev/null 2>/dev/null
-    mqtt-delete-retained "/devices/system__wb-cloud-agent__default/#" >/dev/null 2>/dev/null
-    for provider in $(ls /etc/wb-cloud-agent/providers); do
-        mqtt-delete-retained "/devices/system__wb-cloud-agent__$provider/#" >/dev/null 2>/dev/null
-    done
+    if [[ -e "/usr/sbin/policy-rc.d" ]] && [[ "$(cat /usr/sbin/policy-rc.d)" == "exit 101" ]]; then
+        echo "rootfs building mode, skip removing wb-cloud-agent devices from MQTT"
+    else
+        echo "Removing wb-cloud-agent devices from MQTT"
+        mqtt-delete-retained "/wb-cloud-agent/#" >/dev/null 2>/dev/null
+        mqtt-delete-retained "/devices/system__wb-cloud-agent__default/#" >/dev/null 2>/dev/null
+        for provider in $(ls /etc/wb-cloud-agent/providers); do
+            mqtt-delete-retained "/devices/system__wb-cloud-agent__$provider/#" >/dev/null 2>/dev/null
+        done
+    fi
 fi
 
 if [ "$1" = "purge" ]; then


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
При попытке удалить пакет на этапе сборки рутфс:
```sh
Removing wb-cloud-agent devices from MQTT
dpkg: error processing package wb-cloud-agent (--remove):
 installed wb-cloud-agent package post-removal script subprocess returned error exit status 1
dpkg: too many errors, stopping
Errors were encountered while processing:
 wb-cloud-agent
Processing was halted because there were too many errors.
Error: Sub-process /usr/bin/dpkg returned an error code (1)
```

___________________________________
**Что поменялось для пользователей:**
ничего

___________________________________
**Как проверял/а:**
сборка кастомного фита

