### PR TITLE
Fix cloud connection error message in status publishing

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-cloud-agent (1.6.9) stable; urgency=medium
+
+  * Fix cloud connection error message in status publishing
+
+ -- Denis Smagin <denis.smagin@wirenboard.com>  Thu, 24 Dec 2025 12:45:00 +0100
+
 wb-cloud-agent (1.6.8) stable; urgency=medium
 
   * Internal logic for sending package version to cloud

--- a/wb/cloud_agent/utils.py
+++ b/wb/cloud_agent/utils.py
@@ -123,5 +123,5 @@ def handle_connection_state(prev_value: bool, new_value: bool, msg: str, mqtt: "
     if prev_value != new_value:
         logging.info(msg)
 
-    mqtt.publish_ctrl("status", msg)
+    mqtt.publish_ctrl("status", "ok" if new_value else msg)
     return new_value


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

[SOFT-6384](https://wirenboard.youtrack.cloud/issue/SOFT-6384)

Фикс отображения в homeui сообщения "подключение к облаку успешно" как ошибки

___________________________________
**Что поменялось для пользователей:**

При подключении к облаку нет ошибки

___________________________________
**Как проверял/а:**

Тесты и на контроллере
