### PR TITLE
Bugfix/cloud 259 provider url normalization

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-cloud-agent (1.6.13) stable; urgency=medium
+
+  * Normalize provider base URL to avoid double slash in controller URL
+  * Prevent adding multiple providers with the same URL
+
+ -- Denis Smagin <denis.smagin@wirenboard.com>  Thu, 19 Mar 2026 14:00:00 +0100
+
 wb-cloud-agent (1.6.12) stable; urgency=medium
 
   * Add validation for provider name to prevent invalid characters and whitespace.

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -60,7 +60,7 @@ def test_show_providers_with_data():
 
 @pytest.mark.usefixtures("mock_mqtt_cloud_agent")
 def test_add_provider_success(mock_mqtt_cloud_agent):
-    options = Namespace(base_url="https://example.com", name=None)
+    options = Namespace(base_url="https://example.com/", name=None)
 
     with (
         patch("wb.cloud_agent.commands.configure_app") as mock_config,
@@ -84,7 +84,7 @@ def test_add_provider_success(mock_mqtt_cloud_agent):
 
 @pytest.mark.usefixtures("mock_mqtt_cloud_agent")
 def test_add_provider_with_custom_name():
-    options = Namespace(base_url="https://example.com", name="custom_name:-123.")
+    options = Namespace(base_url="https://example.com/", name="custom_name:-123.")
 
     with (
         patch("wb.cloud_agent.commands.configure_app") as mock_config,
@@ -115,6 +115,28 @@ def test_add_provider_already_exists():
 
         assert result == 1
         mock_print.assert_called_once_with("Provider example.com already exists")
+
+
+@pytest.mark.usefixtures("mock_mqtt_cloud_agent")
+def test_add_provider_with_duplicate_url():
+    options = Namespace(base_url="https://example.com/", name="custom_name")
+    existing_provider = MagicMock()
+    existing_provider.config = {"CLOUD_BASE_URL": "https://example.com"}
+
+    with (
+        patch("wb.cloud_agent.commands.configure_app"),
+        patch("wb.cloud_agent.commands.get_provider_names", return_value=["example.com"]),
+        patch("wb.cloud_agent.commands.load_providers_data", return_value=[existing_provider]),
+        patch("wb.cloud_agent.commands.generate_provider_config") as mock_gen,
+        patch("wb.cloud_agent.commands.start_and_enable_service") as mock_service,
+        patch("builtins.print") as mock_print,
+    ):
+        result = add_provider(options)
+
+        assert result == 1
+        mock_gen.assert_not_called()
+        mock_service.assert_not_called()
+        mock_print.assert_called_once_with("Provider with URL https://example.com already exists")
 
 
 @pytest.mark.usefixtures("mock_mqtt_cloud_agent")

--- a/tests/test_settings_extended.py
+++ b/tests/test_settings_extended.py
@@ -24,7 +24,7 @@ def test_app_settings_with_config_file(tmp_path):
     config_file = config_dir / "wb-cloud-agent.conf"
     config_data = {
         "CLIENT_CERT_ENGINE_KEY": "ATECCx08:00:04:C0:00",
-        "CLOUD_BASE_URL": "https://custom.cloud.com",
+        "CLOUD_BASE_URL": "https://custom.cloud.com/",
         "LOG_LEVEL": "DEBUG",
     }
     config_file.write_text(json.dumps(config_data))
@@ -129,7 +129,7 @@ def test_generate_provider_config(tmp_path):
         patch("wb.cloud_agent.settings.DEFAULT_PROVIDER_CONF_FILE", str(default_conf_file)),
         patch("wb.cloud_agent.settings.PROVIDERS_CONF_DIR", str(providers_dir)),
     ):
-        generate_provider_config("new_provider", "https://new.cloud.com")
+        generate_provider_config("new_provider", "https://new.cloud.com/")
 
         new_conf_file = providers_dir / "new_provider" / "wb-cloud-agent.conf"
         assert new_conf_file.exists()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,6 +6,7 @@ import pytest
 from wb.cloud_agent.settings import AppSettings
 from wb.cloud_agent.utils import (
     get_controller_url,
+    normalize_base_url,
     parse_headers,
     read_json_config,
     read_plaintext_config,
@@ -32,6 +33,15 @@ def test_get_controller_url(mock_serial_number, settings: AppSettings):
         get_controller_url(settings.cloud_base_url)
         == f"{settings.cloud_base_url}/controllers/{mock_serial_number}"
     )
+
+
+def test_get_controller_url_with_trailing_slash(mock_serial_number):
+    assert get_controller_url("https://wirenboard.cloud/") == f"https://wirenboard.cloud/controllers/{mock_serial_number}"
+
+
+def test_normalize_base_url():
+    assert normalize_base_url("https://wirenboard.cloud/") == "https://wirenboard.cloud"
+    assert normalize_base_url("https://wirenboard.cloud") == "https://wirenboard.cloud"
 
 
 def test_parse_headers_basic():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -36,7 +36,10 @@ def test_get_controller_url(mock_serial_number, settings: AppSettings):
 
 
 def test_get_controller_url_with_trailing_slash(mock_serial_number):
-    assert get_controller_url("https://wirenboard.cloud/") == f"https://wirenboard.cloud/controllers/{mock_serial_number}"
+    assert (
+        get_controller_url("https://wirenboard.cloud/")
+        == f"https://wirenboard.cloud/controllers/{mock_serial_number}"
+    )
 
 
 def test_normalize_base_url():

--- a/wb/cloud_agent/commands.py
+++ b/wb/cloud_agent/commands.py
@@ -54,7 +54,9 @@ def add_provider(options) -> int:
         return 1
 
     existing_providers = load_providers_data(providers)
-    if any(normalize_base_url(provider.config["CLOUD_BASE_URL"]) == base_url for provider in existing_providers):
+    if any(
+        normalize_base_url(provider.config["CLOUD_BASE_URL"]) == base_url for provider in existing_providers
+    ):
         print(f"Provider with URL {base_url} already exists")
         return 1
 

--- a/wb/cloud_agent/commands.py
+++ b/wb/cloud_agent/commands.py
@@ -24,6 +24,7 @@ from wb.cloud_agent.settings import (
 )
 from wb.cloud_agent.utils import (
     handle_connection_state,
+    normalize_base_url,
     show_providers_table,
     start_and_enable_service,
 )
@@ -37,7 +38,8 @@ def show_providers(_options) -> int:
 
 
 def add_provider(options) -> int:
-    provider_name = options.name or urlparse(options.base_url).netloc
+    base_url = normalize_base_url(options.base_url)
+    provider_name = options.name or urlparse(base_url).netloc
     settings = configure_app(provider_name=provider_name)
 
     try:
@@ -51,7 +53,12 @@ def add_provider(options) -> int:
         print(f"Provider {provider_name} already exists")
         return 1
 
-    generate_provider_config(provider_name, options.base_url)
+    existing_providers = load_providers_data(providers)
+    if any(normalize_base_url(provider.config["CLOUD_BASE_URL"]) == base_url for provider in existing_providers):
+        print(f"Provider with URL {base_url} already exists")
+        return 1
+
+    generate_provider_config(provider_name, base_url)
     start_and_enable_service(f"wb-cloud-agent@{provider_name}.service")
 
     try:

--- a/wb/cloud_agent/settings.py
+++ b/wb/cloud_agent/settings.py
@@ -19,6 +19,7 @@ from wb.cloud_agent.constants import (
 )
 from wb.cloud_agent.utils import (
     get_controller_url,
+    normalize_base_url,
     read_json_config,
     read_plaintext_config,
 )
@@ -71,6 +72,7 @@ class AppSettings:  # pylint: disable=too-many-instance-attributes disable=too-f
         if not self.skip_conf_file and self.config_file.exists():
             self.apply_conf_file()
 
+        self.cloud_base_url = normalize_base_url(self.cloud_base_url)
         self.cloud_agent_url = self.base_url_to_agent_url(self.cloud_base_url)
 
     def apply_conf_file(self) -> None:
@@ -80,7 +82,7 @@ class AppSettings:  # pylint: disable=too-many-instance-attributes disable=too-f
             setattr(self, key.lower(), val)
 
     def base_url_to_agent_url(self, base_url: str) -> str:
-        parsed = urlparse(base_url)
+        parsed = urlparse(normalize_base_url(base_url))
         netloc = f"agent.{parsed.netloc}"
         return urlunparse((parsed.scheme, netloc, CLOUD_AGENT_URL_POSTFIX, "", "", ""))
 
@@ -104,7 +106,7 @@ def setup_log(settings: AppSettings) -> None:
 
 def generate_provider_config(provider: str, base_url: str) -> None:
     conf = read_json_config(Path(DEFAULT_PROVIDER_CONF_FILE))
-    conf["CLOUD_BASE_URL"] = base_url
+    conf["CLOUD_BASE_URL"] = normalize_base_url(base_url)
 
     conf_dir = Path(PROVIDERS_CONF_DIR) / provider
     if not conf_dir.exists():

--- a/wb/cloud_agent/utils.py
+++ b/wb/cloud_agent/utils.py
@@ -19,9 +19,13 @@ def get_ctrl_serial_number() -> str:
     return subprocess.check_output("wb-gen-serial -s", shell=True).decode().strip()
 
 
+def normalize_base_url(base_url: str) -> str:
+    return base_url.rstrip("/")
+
+
 def get_controller_url(base_url: str) -> str:
     ctrl_serial_number = get_ctrl_serial_number()
-    return urljoin(base_url, f"controllers/{ctrl_serial_number}")
+    return urljoin(normalize_base_url(base_url), f"controllers/{ctrl_serial_number}")
 
 
 def read_json_config(config_path: Path) -> dict[str, str]:


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

[CLOUD-259](https://wirenboard.youtrack.cloud/issue/CLOUD-259/Odinakovye-provajdery-v-wb-cloud-agent)
[CLOUD-390](https://wirenboard.youtrack.cloud/issue/CLOUD-390/Nekorrektnyj-URL-v-homeui)

Добавлена нормализация url провайдеров
Добавлена проверка уникальности url провайдеров

___________________________________
**Что поменялось для пользователей:**

Не смогут создавать повторно провайдеры с таким же url
В homeui не будет некорректного url ссылки на контроллер

___________________________________
**Как проверял/а:**

Тесты, на контроллере
