### PR TITLE
Remove /var/lib/wb-cloud-agent on package purge

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-cloud-agent (1.6.14) stable; urgency=medium
+
+  * Remove /var/lib/wb-cloud-agent on package purge
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 29 Apr 2026 14:10:00 +0400
+
 wb-cloud-agent (1.6.13) stable; urgency=medium
 
   * Normalize provider base URL to avoid double slash in controller URL

--- a/debian/wb-cloud-agent.dirs
+++ b/debian/wb-cloud-agent.dirs
@@ -1,1 +1,2 @@
+/etc/wb-cloud-agent
 /var/lib/wb-cloud-agent

--- a/debian/wb-cloud-agent.dirs
+++ b/debian/wb-cloud-agent.dirs
@@ -1,0 +1,1 @@
+/var/lib/wb-cloud-agent

--- a/debian/wb-cloud-agent.postrm
+++ b/debian/wb-cloud-agent.postrm
@@ -22,6 +22,8 @@ fi
 if [ "$1" = "purge" ]; then
     rm -f /etc/wb-cloud-agent.conf
     rm -fr /etc/wb-cloud-agent
+    rm -fr /etc/wb-cloud-agent.default
+    rm -fr /var/lib/wb-cloud-agent
 fi
 
 #DEBHELPER#

--- a/debian/wb-cloud-agent.postrm
+++ b/debian/wb-cloud-agent.postrm
@@ -21,6 +21,7 @@ fi
 
 if [ "$1" = "purge" ]; then
     rm -f /etc/wb-cloud-agent.conf
+    rm -f /etc/wb-cloud-agent.conf.default
     rm -fr /etc/wb-cloud-agent
     rm -fr /etc/wb-cloud-agent.default
     rm -fr /var/lib/wb-cloud-agent


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
после `apt purge wb-cloud-agent` оставались /etc/wb-cloud-agent.default и /var/lib/wb-cloud-agent

___________________________________
**Что поменялось для пользователей:**
ничего

___________________________________
**Как проверял/а:**
локально

